### PR TITLE
docs: fix phenopackets schema docs URL

### DIFF
--- a/src/data/resources.yaml
+++ b/src/data/resources.yaml
@@ -128,7 +128,7 @@ standards:
     name: Phenopackets
     monarch_contribution: Lead
     category: Data Exchange
-    documentation: https://phenopackets-schema.readthedocs.io/en/latest/
+    documentation: https://phenopacket-schema.readthedocs.io/en/latest/
     url: http://phenopackets.org/
     icon: resource-phenopackets
     grants:

--- a/src/docs/registry.md
+++ b/src/docs/registry.md
@@ -20,7 +20,7 @@ the diverse ecosystem of tools, data and standards that Monarch supports.
 | PURL | https://standards.monarchinitiative.org/phenopackets |
 | Cite |  |
 | [Resource category](../Documentation-Schema/StandardEnum/) | Data Exchange |
-| Documentation | [https://phenopackets-schema.readthedocs.io/en/latest/](https://phenopackets-schema.readthedocs.io/en/latest/) | 
+| Documentation | [https://phenopacket-schema.readthedocs.io/en/latest/](https://phenopacket-schema.readthedocs.io/en/latest/) | 
 | [Monarch role](../Documentation-Schema/MonarchContributionEnum/) in the development | Lead |
 | [Grants](../Documentation-Schema/GrantEnum/) involved in this standard | Phenomics First |
 | [Role in Monarchs strategic vision](../Documentation-Schema/MonarchRoleEnum/) | Flagship |


### PR DESCRIPTION
Randomly noticed that this URL was broken. Easy fix.